### PR TITLE
Add Agent tag to all skeleton GOs

### DIFF
--- a/Packages/com.pg649.creaturegenerator/Runtime/SkeletonGeneration/SkeletonAssembler.cs
+++ b/Packages/com.pg649.creaturegenerator/Runtime/SkeletonGeneration/SkeletonAssembler.cs
@@ -88,6 +88,7 @@ public class SkeletonAssembler {
 
         // TOOD(markus): Name
         GameObject result = new GameObject("");
+        result.tag = "Agent";
 
 
 
@@ -164,6 +165,7 @@ public class SkeletonAssembler {
             float r = 0.1f;
             if(attachPrimitiveMesh){
                 meshObject = GameObject.CreatePrimitive(PrimitiveType.Sphere);
+                meshObject.tag = "Agent";
                 meshObject.transform.localScale = new Vector3(0.1f, 0.1f ,0.1f);
 
                 meshObject.transform.parent = result.transform;
@@ -180,6 +182,7 @@ public class SkeletonAssembler {
             Vector3 size = new Vector3(0.1f, self.Length * 0.9f, 0.05f);
             if(attachPrimitiveMesh){
                 meshObject = GameObject.CreatePrimitive(PrimitiveType.Cube);                        
+                meshObject.tag = "Agent";
                 meshObject.transform.localScale = size;
 
                 meshObject.transform.parent = result.transform;
@@ -193,6 +196,7 @@ public class SkeletonAssembler {
         } else {
             if(attachPrimitiveMesh){
                 meshObject = GameObject.CreatePrimitive(PrimitiveType.Capsule);
+                meshObject.tag = "Agent";
                 meshObject.transform.localScale = new Vector3(0.1f,self.Length*0.45f,0.1f);
 
                 meshObject.transform.parent = result.transform;

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -3,7 +3,8 @@
 --- !u!78 &1
 TagManager:
   serializedVersion: 2
-  tags: []
+  tags:
+  - Agent
   layers:
   - Default
   - TransparentFX


### PR DESCRIPTION
Unitys Tags sind nicht einfach Strings, sondern muessen entweder per Hand zur Tagliste hinzugefuegt werden oder mittels Editor Skript erstellt werden. Ich hab den Agent Tag bei mir hinzugefuegt, aber bin mir nicht sicher wo Unity die erstellten Tags speichert und ob git sie versioniert.

Bitte einmal lokal versuchen das Projekt zu starten und schauen ob es Fehler wegen des fehlenden Tags gibt.